### PR TITLE
Correctly sort pairs

### DIFF
--- a/lib/GoCardless/Utils.php
+++ b/lib/GoCardless/Utils.php
@@ -61,7 +61,7 @@ class GoCardless_Utils {
         return '';
       }
 
-      sort($pairs);
+      usort($pairs, array(__CLASS__, 'sortPairs'));
 
       $strs = array();
       foreach ($pairs as $pair) {
@@ -76,6 +76,24 @@ class GoCardless_Utils {
 
     }
 
+  }
+
+  /**
+   * Sorts a pair
+   *
+   * @param array $a
+   * @param array $b
+   * @return int
+   */
+  public static function sortPairs($a, $b)
+  {
+    $keys = strcmp($a[0], $b[0]);
+
+    if ($keys !== 0) {
+      return $keys;
+    }
+
+    return strcmp($a[1], $b[1]);
   }
 
   /**

--- a/tests/lib/UtilsTest.php
+++ b/tests/lib/UtilsTest.php
@@ -66,6 +66,33 @@ class Test_Utils extends PHPUnit_Framework_TestCase {
 
   }
 
+
+  /**
+   *
+   * Test for correct sorting of keys/values
+   */
+  public function testGenerateQueryStringSortsByKeyThenValue() {
+
+    $params = array(
+      'bills' => array(
+        array(
+          'amount' => 10.0,
+          'amount_minus_fees' => 9.9,
+        ),
+        array(
+          'amount' => 19.99,
+          'amount_minus_fees' => 19.79,
+        ),
+      ),
+    );
+
+
+    $sig = GoCardless_Utils::generate_query_string($params);
+
+    // Check against a pre-built hash
+    $this->assertEquals('bills%5B%5D%5Bamount%5D=10&bills%5B%5D%5Bamount%5D=19.99&bills%5B%5D%5Bamount_minus_fees%5D=19.79&bills%5B%5D%5Bamount_minus_fees%5D=9.9', $sig);
+  }
+
 	/**
 	 * Check the signature is being generated correctly
 	 */


### PR DESCRIPTION
PHP's sort isn't really suitable for this, I don't really think you can guarantee what it's going to do with a multidimensional array.

I've tried to write this in a way that's compatible with 5.2, but I've pretty much forgotten the best practices etc now we've got closures in 5.3 

Also, your documentation states:

> Your server should validate the HMAC digest by resigning the received parameters (more information under "Signing Requests" in the Connect Guide) and respond with status HTTP/1.1 200 OK within 5 seconds. If the API server does not get a 200 OK response within this time, it will retry up to 10 times at ever-increasing time intervals.

We've had the same webhook sent through 13,000 times in just over a day, we were returning a 500 status code as we failed to match signatures (because of the bug this PR fixes), so you might want to look in to your scheduling.
