### PR TITLE
Improves GoCardless_ApiException

### DIFF
--- a/lib/GoCardless/Exceptions.php
+++ b/lib/GoCardless/Exceptions.php
@@ -76,6 +76,13 @@ class GoCardless_ApiException extends Exception {
     return json_decode($this->json, true);
   }
 
+  public function getError() {
+    // This is primitive way of trying to extract the errors, your mileage may
+    // vary - use getJson() or getResponse() for something more robust
+    $object = json_decode($this->json, true);
+    return reset(reset($object["errors"]));
+  }
+
 }
 
 /**

--- a/lib/GoCardless/Exceptions.php
+++ b/lib/GoCardless/Exceptions.php
@@ -55,11 +55,25 @@ class GoCardless_ApiException extends Exception {
    * @param string $description Description of the error
    * @param integer $code The returned error code
    */
-  public function __construct($description = 'Unknown error', $code = 0) {
+
+  private $json;
+
+  public function __construct($description = 'Unknown error', $code = 0, $json = null) {
     if (empty($description)) {
       $description = 'Unknown error';
     }
+
+    $this->json = $json;
+
     parent::__construct($description, $code);
+  }
+
+  public function getJson() {
+    return $this->json;
+  }
+
+  public function getResponse() {
+    return json_decode($this->json, true);
   }
 
 }

--- a/lib/GoCardless/Request.php
+++ b/lib/GoCardless/Request.php
@@ -193,7 +193,7 @@ class GoCardless_Request {
       $message = print_r(json_decode($result, true), true);
 
       // Throw an exception with the error message
-      throw new GoCardless_ApiException($message, $http_response_code);
+      throw new GoCardless_ApiException($message, $http_response_code, $result);
 
     }
 


### PR DESCRIPTION
Previously, the `GoCardless_ApiException` exceptions raised by Request.php weren't very helpful as the message contained only the result of calling `print_r` on the JSON.

This actually stores the JSON in the exception object, so you can call `$exception->getJson()` to get the raw JSON returned bu GoCardless, or `$exception->getResponse()` to get a decoded object of it. You can also call `$exception->getError()` and this will try to get the _actual_ error, by your mileage may vary on this one.

resolves issue #13 
