### PR TITLE
Adds support for partner pre-population in authorize_url

### DIFF
--- a/lib/GoCardless/Client.php
+++ b/lib/GoCardless/Client.php
@@ -101,13 +101,18 @@ class GoCardless_Client {
       throw new GoCardless_ArgumentsException('redirect_uri required');
     }
 
-    $endpoint = '/oauth/authorize';
+    $endpoint = '/oauth/authorize/?';
 
-    return $this->base_url . $endpoint .
-      '?client_id='. urlencode($this->account_details['app_id']) .
-      '&redirect_uri=' . urlencode($options['redirect_uri']) .
-      '&scope=manage_merchant' .
-      '&response_type=code';
+    $required_options = array(
+      "client_id" => $this->account_details['app_id'],
+      "scope" => "manage_merchant",
+      "response_type" => "code"
+    );
+
+    $params = array_merge($required_options, $options);
+    $request = GoCardless_Utils::generate_query_string($params);
+
+    return $this->base_url . $endpoint . $request;
 
   }
 


### PR DESCRIPTION
Previously, unlike in other libraries, partners could not pre-populate details about a prospective merchant (e.g. email address, company name, type of business) using the `authorize_url` method - they simply had to append onto the generated URL. You can read more about the pre-population options [here](https://gocardless.com/docs/partner_guide#prepopulating-information).

The method now merges all the attributes passed into its `$options` parameter in the request, so it can support pre-population and any other options that we might see fit to add in future.

Now you can do something like this:

``` php
<?php
// ...
$authorize_url_options = array(
  'redirect_uri' => 'http://localhost/~tim/gc/redirect.php',
  'merchant' => array(
    'name' => "Tim Rogers"
  )
);
print $gocardless_client->authorize_url($authorize_url_options);
?>
```

fixes #17
