### PR TITLE
Fix the return annotation for fetch_access_token

### DIFF
--- a/lib/GoCardless/Client.php
+++ b/lib/GoCardless/Client.php
@@ -119,7 +119,7 @@ class GoCardless_Client {
    *
    * @param array $params The parameters to use
    *
-   * @return string The access token
+   * @return array The access token
    */
   public function fetch_access_token($params) {
 

--- a/lib/GoCardless/Client.php
+++ b/lib/GoCardless/Client.php
@@ -119,7 +119,7 @@ class GoCardless_Client {
    *
    * @param array $params The parameters to use
    *
-   * @return array The access token
+   * @return array Array containing the Merchant ID ('merchant_id') and Access Token ('access_token')
    */
   public function fetch_access_token($params) {
 


### PR DESCRIPTION
As you can see by the return value in the function, it returns an array, not a string.  Thought it worth changing to avoid IDEs incorrectly autocompleting annotations for other functions which call this.
