### PR TITLE
Always add CURLOPT_POSTFIELDS for a POST request

### DIFF
--- a/lib/GoCardless/Request.php
+++ b/lib/GoCardless/Request.php
@@ -125,11 +125,7 @@ class GoCardless_Request {
       // Curl options for POSt
 
       $curl_options[CURLOPT_POST] = 1;
-
-      if ( ! empty($params)) {
-        $curl_options[CURLOPT_POSTFIELDS] = http_build_query($params, null,
-          '&');
-      }
+      $curl_options[CURLOPT_POSTFIELDS] = http_build_query($params, null, '&');
 
     } elseif ($method == 'get') {
       // Curl options for GET


### PR DESCRIPTION
PHP (5.5.8 on my machine) seemed to be adding header 

```
Content-Length: -1
```

If a POST request has no CURLOPT_POSTFIELDS defined, causing a 400 Bad Request from GoCardless.

This caused retry/refund requests to always fail.
