### PR TITLE
Make getError more robust

### DIFF
--- a/lib/GoCardless/Exceptions.php
+++ b/lib/GoCardless/Exceptions.php
@@ -77,13 +77,23 @@ class GoCardless_ApiException extends Exception {
   }
 
   public function getError() {
-    // This is primitive way of trying to extract the errors, your mileage may
-    // vary - use getJson() or getResponse() for something more robust
     $object = json_decode($this->json, true);
+    $message = array("HTTP status {$this->code}");
 
-    // reset() gets the first element in an associative array, since we don't
-    // know necessarily what the keys will be
-    return reset(reset($object["errors"]));
+    if (isset($object["errors"])) {
+      foreach ($object["errors"] as $key => $val) {
+        if (is_array($val)) $val = implode(', ', $val);
+        $message[] = "{$key} {$val}";
+      }
+    }
+
+    if (isset($object["error"])) {
+      foreach ($object["error"] as $val) {
+        $message[] = $val;
+      }
+    }
+
+    return implode('. ', $message);
   }
 
 }


### PR DESCRIPTION
@hmarr Not required, given your branch on GC, but this PR should make the getError function useful again!

Returns something like:
`HTTP status 422. amount is not a number. charge_customer_at is not in the future`
